### PR TITLE
fix: resolve undefined errors

### DIFF
--- a/calyptia-bats.sh
+++ b/calyptia-bats.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -euox pipefail
+set -euo pipefail
 
 # The root of the tests to run locally, i.e. the custom test files we want to execute.
 export TEST_ROOT=${TEST_ROOT:?}
@@ -75,7 +75,7 @@ function install_bats() {
 # Helper function to run a set of tests based on our specific configuration
 # This function will call `exit`, so any cleanup must be done inside of it.
 function run_tests() {
-    local requested=$1
+    local requested=${1:-}
     local run=""
 
     if [[ "$requested" == "all" ]] || [ -z "$requested" ]; then


### PR DESCRIPTION
Line 78 triggers an undefined error when run with no parameters, i.e. for all tests, from #7.

e.g. https://github.com/chronosphereio/calyptia-core-fluent-bit/actions/runs/12009510078/job/33475010931?pr=376