### PR TITLE
Remove tracing by default

### DIFF
--- a/calyptia-bats.sh
+++ b/calyptia-bats.sh
@@ -18,7 +18,7 @@ export CUSTOM_HELPERS_ROOT=${CUSTOM_HELPERS_ROOT:-$TEST_ROOT/helpers/}
 # Some common options
 export CONTAINER_RUNTIME=${CONTAINER_RUNTIME:-docker}
 export BATS_FORMATTER=${BATS_FORMATTER:-tap}
-export BATS_ARGS=${BATS_ARGS:---timing --verbose-run --print-output-on-failure --trace}
+export BATS_ARGS=${BATS_ARGS:---timing --verbose-run}
 
 # BATS installation location
 export BATS_ROOT=${BATS_ROOT:-$CALYPTIA_BATS_DIR/bats}


### PR DESCRIPTION
The tracing output is very verbose and hard to use: https://github.com/chronosphereio/calyptia-core-fluent-bit/actions/runs/12071966104/job/33665418749?pr=378

Reverting to previous settings.